### PR TITLE
Add `mkdir unit_tests` command

### DIFF
--- a/repo_setup.sh
+++ b/repo_setup.sh
@@ -146,6 +146,7 @@ fi
 
 # If the CPPUTEST folder doesn't exist, install cpputest
 if [ ! -d $CURRENT_PATH/unit_tests/cpputest ]; then
+    mkdir unit_tests
     cd unit_tests
     git clone https://github.com/cpputest/cpputest.git
     cd cpputest

--- a/repo_setup.sh
+++ b/repo_setup.sh
@@ -146,7 +146,7 @@ fi
 
 # If the CPPUTEST folder doesn't exist, install cpputest
 if [ ! -d $CURRENT_PATH/unit_tests/cpputest ]; then
-    mkdir unit_tests
+    mkdir -p unit_tests
     cd unit_tests
     git clone https://github.com/cpputest/cpputest.git
     cd cpputest


### PR DESCRIPTION
The `unit_tests` folder was not in the repo. Thus, the `cpputest` folder would be created in the root folder.